### PR TITLE
Add Secret Scanner Workflow

### DIFF
--- a/.github/workflows/secret-scanner.yaml
+++ b/.github/workflows/secret-scanner.yaml
@@ -1,0 +1,16 @@
+name: "Secret Scanner"
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  secrets-scanner:
+    uses: arbor-education/gha.workflows/.github/workflows/secret-scanner-template.yaml@DOPS-12604-cicd-scanner
+    secrets:
+      JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}


### PR DESCRIPTION
This PR adds the secret scanner workflow to the repository.

Changes:
- Added secret-scanner.yaml workflow file
- Configured to run on push and pull request events
- Uses the shared workflow from arbor-education/gha.workflows